### PR TITLE
[DPE-7759] - chore: bump karapace to 5.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: get-version
         name: Retrieve workload version
@@ -25,7 +25,7 @@ jobs:
 
       - id: upload
         name: Upload built snap job artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: charmed-karapace_snap_amd64
           path: charmed-karapace_${{ steps.get-version.outputs.version }}_amd64.snap
@@ -40,7 +40,7 @@ jobs:
       - build
     steps:
       - name: Download snap file
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: charmed-karapace_snap_amd64
           path: .

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
-          release: latest/edge
+          release: 5/edge
       - name: Upload snapcraft logs
         if: ${{ failure() && steps.publish.outcome == 'failure' }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,60 +1,31 @@
-name: Publish new Karapace SNAP revision
+name: Publish new Karapace Snap revision
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:
     branches:
       - 'main'
+      - '5/edge'
   workflow_call:
   workflow_dispatch:
 
 jobs:
-  checks:
-    name: Check Metadata and branch consistency
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v3
-
-      - id: get-current-version
-        name: Retrieve Metadata
-        run: |
-          VERSION=$(yq '(.version|split("-"))[0]' snap/snapcraft.yaml)
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-
-          BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
-          echo "risk=${BRANCH##*\/}" >> $GITHUB_OUTPUT
-          echo "track=${BRANCH%*\/*}" >> $GITHUB_OUTPUT
-
   build:
     name: Build snap
-    needs: checks
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap_without_cache.yaml@v2
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v32.0.0
 
-  publish:
-    name: Publish Snap
-    runs-on: ubuntu-latest
-    needs: build
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.build.outputs.artifact-name }}
-      - id: get-snap-name
-        run: echo "SNAP_FILE=$(ls *.snap)" >> $GITHUB_OUTPUT
-      - name: Publish snap
-        id: publish
-        uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
-          release: 5/edge
-      - name: Upload snapcraft logs
-        if: ${{ failure() && steps.publish.outcome == 'failure' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: snapcraft-release-logs
-          path: ~/.local/state/snapcraft/log/
-          if-no-files-found: error
+  release:
+    name: Release snap
+    needs:
+      - build
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v32.0.0
+    with:
+      channel: 5/edge
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
+    secrets:
+      snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}
+    permissions:
+      contents: write

--- a/snap/local/opt/karapace/bin/start-wrapper.bash
+++ b/snap/local/opt/karapace/bin/start-wrapper.bash
@@ -6,4 +6,4 @@ set -e
     --clear-groups \
     --reuid snap_daemon \
     --regid snap_daemon -- \
-    "${SNAP}/bin/karapace" "${SNAP_DATA}"/etc/karapace/karapace.config.json
+    bash -c "\"${SNAP}/bin/python\" -m karapace \"${SNAP_DATA}\"/etc/karapace/karapace.config.json >> \"${SNAP_COMMON}/var/log/karapace/output.log\""

--- a/snap/local/opt/karapace/bin/version.bash
+++ b/snap/local/opt/karapace/bin/version.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+"${SNAP}"/bin/python -c 'from karapace import version; print(version.__version__)'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-karapace
-base: core22
-version: '3.12.0'
+base: core24
+version: '5.0.0'
 summary: Karapace on a snap
 description: |
   This is a snap that bundles Karapace in order to be used in Charmed Operators, providing
@@ -30,7 +30,7 @@ apps:
       - network
       - network-bind
   version:
-    command: bin/karapace --version
+    command: opt/karapace/bin/version.bash
   mkpasswd:
     command: bin/karapace_mkpasswd
 
@@ -43,8 +43,7 @@ parts:
         - wheel
         - pip
         - sentry_sdk
-    python-requirements:
-        - ./requirements/requirements.txt
+        - setuptools-golang
     stage-packages:
         - util-linux
   wrapper:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,6 +51,12 @@ parts:
     plugin: python
     source: https://github.com/Aiven-Open/karapace.git  # pip install git+https://github.com/Aiven-Open/karapace@main
     source-tag: ${SNAPCRAFT_PROJECT_VERSION}
+    override-pull: |
+      craftctl default
+      # bump confluent-kafka version
+      sed -i 's/"confluent-kafka == 2\.4\.0",/  "confluent-kafka == 2.11.0",/' pyproject.toml
+    build-snaps:
+        - go
     python-packages:
         - wheel
         - pip

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,17 +13,24 @@ confinement: strict
 system-usernames:
   snap_daemon: shared
 
-# COS INTEGRATION
-# slots:
-#   logs:
-#     interface: content
-#     source:
-#       read:
-#         - $SNAP_COMMON/var/log/karapace
+slots:
+  logs:
+    interface: content
+    content: logs
+    source:
+      read:
+        - $SNAP_COMMON/var/log/karapace
 
 apps:
   daemon:
     command: opt/karapace/bin/start-wrapper.bash
+    daemon: simple
+    install-mode: disable
+    plugs:
+      - network
+      - network-bind
+  statsd-exporter:
+    command: bin/statsd_exporter
     daemon: simple
     install-mode: disable
     plugs:
@@ -35,6 +42,11 @@ apps:
     command: bin/karapace_mkpasswd
 
 parts:
+  statsd-exporter:
+    plugin: go
+    source: https://github.com/prometheus/statsd_exporter.git
+    build-snaps:
+        - go
   karapace:
     plugin: python
     source: https://github.com/Aiven-Open/karapace.git  # pip install git+https://github.com/Aiven-Open/karapace@main


### PR DESCRIPTION
## Changes Made
#### `cicd: use dp workflows snap build + publish actions`
#### `feat: add 5.0.0 support`
- Includes fix for broken `confluent-kafka` version w. Kafka 4 (due to [KIP-896](https://cwiki.apache.org/confluence/display/KAFKA/KIP-896%3A+Remove+old+client+protocol+API+versions+in+Kafka+4.0))
#### `feat: log out to $SNAP_DATA/var/log/karapace/output.log`
#### `chore: add statsd_exporter`
- This may not work, and may be removed in future releases depending on what's needed for o11y integration with the OTel Collector