### PR TITLE
[DPE-7457] fix: snap logs not populated

### DIFF
--- a/snap/local/opt/karapace/bin/start-wrapper.bash
+++ b/snap/local/opt/karapace/bin/start-wrapper.bash
@@ -6,4 +6,4 @@ set -e
     --clear-groups \
     --reuid snap_daemon \
     --regid snap_daemon -- \
-    bash -c "\"${SNAP}/bin/python\" -m karapace \"${SNAP_DATA}\"/etc/karapace/karapace.config.json >> \"${SNAP_COMMON}/var/log/karapace/output.log\""
+    bash -c "\"${SNAP}/bin/python\" -m karapace \"${SNAP_DATA}\"/etc/karapace/karapace.config.json | tee -a \"${SNAP_COMMON}/var/log/karapace/output.log\""


### PR DESCRIPTION
Fixes https://github.com/canonical/charmed-karapace-snap/issues/4