### PR TITLE
ci: fix release flow

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,9 @@ description: |
 
 confinement: strict
 
+platforms:
+  amd64:
+
 system-usernames:
   snap_daemon: shared
 


### PR DESCRIPTION
Added `platforms` key to `snapcraft.yaml` in an attempt to fix [release workflow](https://github.com/canonical/charmed-karapace-snap/actions/runs/17210953320).